### PR TITLE
Add documentation for words related to string and numeric literals

### DIFF
--- a/documentation.frt
+++ b/documentation.frt
@@ -69,3 +69,13 @@ Read hexadecimal literal
 ( -- number )
 Read octal literal
 " doc-word
+
+' O_CREAT g"
+( -- 0x40 )
+Push a flag O_CREAT (create new file if pathname does not exist) onto stack
+" doc-word
+
+' O_APPEND g"
+( -- 0x400 )
+Push a flag O_APPEND (seek to the end of file) onto stack
+" doc-word


### PR DESCRIPTION
The following words were documented:

- `O_CREAT`
- `O_APPEND`
- `0x`
- `08x`
- `read-oct-digit`
- `read-hex-digit`
- `read-digit`
- `."`
- `g"`
- `"`
- `_"`